### PR TITLE
Set se_quality_mod_detected through settings.lua

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,1 @@
+data.raw["bool-setting"]["se-enable-data-stage-quality-mod-compatibility"].forced_value = true

--- a/settings.lua
+++ b/settings.lua
@@ -1,1 +1,3 @@
-data.raw["bool-setting"]["se-enable-data-stage-quality-mod-compatibility"].forced_value = true
+if data.raw["bool-setting"]["se-enable-data-stage-quality-mod-compatibility"] then
+   data.raw["bool-setting"]["se-enable-data-stage-quality-mod-compatibility"].forced_value = true
+end


### PR DESCRIPTION
In a future SE version `se_quality_mod_detected` will be removed and swapped with this so we can use it in the first data stage as well, not sure yet which version it'll be, but with this change your mod will be future proof.